### PR TITLE
Removed deprecations for Symfony 2.8

### DIFF
--- a/Extension/GettextTranslationExtension.php
+++ b/Extension/GettextTranslationExtension.php
@@ -16,10 +16,10 @@ class GettextTranslationExtension extends \Twig_Extension
   public function getFunctions()
   {
     return array(
-      '_' => new \Twig_Function_Function('gettext'),
-      '_n' => new \Twig_Function_Function('ngettext'),
-      '__' => new \Twig_Function_Method($this, 'gettext'),
-      '__n' => new \Twig_Function_Method($this, 'ngettext'),
+      new \Twig_SimpleFunction('_', 'gettext'),
+      new \Twig_SimpleFunction('_n', 'ngettext'),
+      new \Twig_SimpleFunction('__' , array($this, 'gettext')),
+      new \Twig_SimpleFunction('__n', array($this, 'ngettext')),
     );
   }
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -9,6 +9,6 @@ services:
       - { name: twig.extension }
   lsw_gettext_locale_listener:
     class: %lsw_gettext_locale_listener.class%
-    arguments: [%gettext.locale_shortcuts%,@router, %kernel.root_dir%]
+    arguments: [%gettext.locale_shortcuts%, "@router", %kernel.root_dir%]
     tags:
       - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }

--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,9 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": ">=2.1",
-        "symfony/security-bundle": ">=2.1"
+        "twig/twig": "~1.12"
     },
     "require-dev": {
-        "twig/twig": "*",
-        "doctrine/doctrine-bundle": "*",
-        "swiftmailer/swiftmailer": "*",
-        "willdurand/propel-typehintable-behavior": "dev-master",
-        "symfony/yaml": "2.1.*",
-        "symfony/validator": "2.1.*"
     },
     "autoload": {
         "psr-0": { "Lsw\\GettextTranslationBundle": "" }


### PR DESCRIPTION
Hi all,

I removed the deprecation warnings for use with Symfony 2.8 and above. Would be nice if you can merge it so we do not have to maintain our own version. If I need to do more work before you will merge please let me know. I tried to make the changes as minimal as possible.