### PR TITLE
Remove deprecation messages for unquoted vars

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,11 +4,11 @@ parameters:
   
 services:
   lsw_gettext_translation_extension:
-    class: %lsw_gettext_translation_extension.class%
+    class: '%lsw_gettext_translation_extension.class%'
     tags:
       - { name: twig.extension }
   lsw_gettext_locale_listener:
-    class: %lsw_gettext_locale_listener.class%
-    arguments: [%gettext.locale_shortcuts%, "@router", %kernel.root_dir%]
+    class: '%lsw_gettext_locale_listener.class%'
+    arguments: ['%gettext.locale_shortcuts%', "@router", '%kernel.root_dir%']
     tags:
       - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }


### PR DESCRIPTION
Remove the deprecation messages like:
`Not quoting the scalar "%lsw_gettext_locale_listener.class%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0.`
