### PR TITLE
Changed composer.json file for compatibility with Twig 2.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": ">=2.1",
-        "twig/twig": "~1.12"
+        "twig/twig": ">=1.12"
     },
     "require-dev": {
     },


### PR DESCRIPTION
In the current composer.json dependencies configuration — twig downgraded from v2.* branch to v1.*.

>` Changelogs summary:`
>`  - twig/twig downgraded from v2.1.0 to v1.31.0`

I fixed it.