### PR TITLE
Fixed compatibility with Symfony 3.2.x and Twig 2.x

### DIFF
--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -10,10 +10,6 @@
 namespace Lsw\GettextTranslationBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-
 use Symfony\Component\Process\Process;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
@@ -97,8 +93,7 @@ abstract class AbstractCommand extends ContainerAwareCommand
             mkdir($dir, 0755, true);
         }
 
-        $templates = array();
-        if ( $name === 'app' ) {
+        if ($name === 'app') {
             $templates = $this->findFilesInFolder($dir . '/../../', 'twig');
         } else {
             $templates = $this->findFilesInFolder($dir . '/../views', 'twig');
@@ -106,16 +101,35 @@ abstract class AbstractCommand extends ContainerAwareCommand
 
         $php  = "<?php\n";
         $twig = $this->getContainer()->get('twig');
-        $twig->setLoader(new \Twig_Loader_String());
+
+        /** @var \Twig_Loader_Filesystem $loader */
+        $loader = $twig->getLoader();
+
         foreach ($templates as $templateFileName) {
-            $stream = $twig->tokenize(file_get_contents($templateFileName));
+            $filename = $templateFileName;
+            if (0 === mb_strpos($filename, 'app/Resources/views/')) {
+                $filename = mb_substr($filename, 20);
+            } elseif ($name !== 'app') {
+                $filename       = $templateFileName;
+                $bundleViewsDir = $name . '/Resources/views';
+                $filnamePos     = mb_strpos($filename, $bundleViewsDir);
+                if ($filnamePos === false) {
+                    continue;
+                }
+
+                $filnamePos += mb_strlen($bundleViewsDir) + 1;
+                $loader->addPath(mb_substr($filename, 0, $filnamePos));
+                $filename = mb_substr($filename, $filnamePos);
+            }
+
+            $stream = $twig->tokenize(new \Twig_Source(file_get_contents($templateFileName), $filename));
             $nodes = $twig->parse($stream);
             $template = $twig->compile($nodes);
             // remove first line
             $template = substr($template, strpos($template, "\n")+strlen("\n"));
             $php .= "/*\n * Resource: $name\n * File: $templateFileName\n */\n";
             $php .= $template;
-            $results[$templateFileName]='Scanned';
+            $results[$templateFileName] = 'Scanned';
         }
 
         if (!file_put_contents($path, $php)) {
@@ -142,7 +156,7 @@ abstract class AbstractCommand extends ContainerAwareCommand
         }
 
         // clean .tmp file for further using it as cache
-        if (file_exists("$path.tmp"))  {
+        if (file_exists("$path.tmp")) {
             unlink("$path.tmp");
         }
 
@@ -150,7 +164,7 @@ abstract class AbstractCommand extends ContainerAwareCommand
         $files = $this->findFilesInFolder(dirname($path) . '/../..', 'php');
 
         // define options for finding translation strings within *.php files
-        $options = implode(' ',array(
+        $options = implode(' ', array(
             '--keyword=__:1',
             '--keyword=__n:1,2',
             '--keyword=_:1',
@@ -163,7 +177,7 @@ abstract class AbstractCommand extends ContainerAwareCommand
         ));
 
         $process = new Process('xgettext '.$options);
-        $process->setStdin(implode("\n", $files));
+        $process->setInput(implode("\n", $files));
         $process->run();
         $output = $process->getOutput();
         if (!$process->isSuccessful()) {
@@ -242,7 +256,7 @@ abstract class AbstractCommand extends ContainerAwareCommand
         // clean .tmp file for further using it as cache
         if (!file_exists(dirname($path))) {
             mkdir(dirname($path), 0755, true);
-        } else if (file_exists("$path.tmp")) {
+        } elseif (file_exists("$path.tmp")) {
             unlink("$path.tmp");
         }
 
@@ -255,7 +269,7 @@ abstract class AbstractCommand extends ContainerAwareCommand
         ));
 
         $process = new Process('msgcat '.$options);
-        $process->setStdin(implode("\n", $files));
+        $process->setInput(implode("\n", $files));
         $process->run();
         $output = $process->getOutput();
 

--- a/Command/ExtractBundleCommand.php
+++ b/Command/ExtractBundleCommand.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
@@ -59,6 +60,8 @@ EOT
      * @param OutputInterface $output Output interface
      *
      * @see Command
+     *
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -84,6 +87,8 @@ EOT
         if (!$input->getOption('keep-cache')) {
             unlink($twig);
         }
+
+        return 0;
     }
 
     /**
@@ -93,23 +98,24 @@ EOT
      * @param OutputInterface $output Output interface
      *
      * @see Command
-     * @return mixed
+     * @return void
      */
     protected function interact(InputInterface $input, OutputInterface $output)
     {
         if (!$input->getArgument('bundle')) {
-            $bundle = $this->getHelper('dialog')->askAndValidate(
-                $output,
-                'Please give the bundle:',
-                function($bundle)
-                {
-                    if (empty($bundle)) {
-                        throw new \Exception('Bundle can not be empty');
-                    }
-
-                    return $bundle;
+            $questionHelper = $this->getHelper('question');
+            $bundleQuestion = new Question('Please give the bundle: ');
+            $bundleQuestion->setValidator(function ($bundle) {
+                if (empty($bundle)) {
+                    throw new \RuntimeException(
+                        'Bundle can not be empty'
+                    );
                 }
-            );
+
+                return $bundle;
+            });
+
+            $bundle = $questionHelper->ask($input, $output, $bundleQuestion);
             $input->setArgument('bundle', $bundle);
         }
     }

--- a/Command/InitializeApplicationCommand.php
+++ b/Command/InitializeApplicationCommand.php
@@ -2,14 +2,10 @@
 
 namespace Lsw\GettextTranslationBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-
-use Symfony\Component\Finder\Finder;
-use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Console\Question\Question;
 
 /**
  * InitializeBundleCommand extracts records to be translated from the current application
@@ -54,6 +50,8 @@ EOT
      * @param OutputInterface $output Output interface
      *
      * @see Command
+     *
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -65,6 +63,8 @@ EOT
         foreach ($results as $filename => $status) {
             $output->writeln("$status: $filename");
         }
+
+        return 0;
     }
 
     /**
@@ -74,23 +74,24 @@ EOT
      * @param OutputInterface $output Output interface
      *
      * @see Command
-     * @return mixed
+     * @return void
      */
     protected function interact(InputInterface $input, OutputInterface $output)
     {
         if (!$input->getArgument('languages')) {
-            $languages = $this->getHelper('dialog')->askAndValidate(
-                $output,
-                'Please enter the list of languages (comma seperated):',
-                function($languages)
-                {
-                  if (empty($languages)) {
-                    throw new \Exception('Language list can not be empty');
-                  }
-
-                  return $languages;
+            $questionHelper = $this->getHelper('question');
+            $question = new Question('Please enter the list of languages (comma seperated): ');
+            $question->setValidator(function ($languages) {
+                if (empty($languages)) {
+                    throw new \RuntimeException(
+                        'Language list can not be empty'
+                    );
                 }
-            );
+
+                return $languages;
+            });
+
+            $languages = $questionHelper->ask($input, $output, $question);
             $input->setArgument('languages', $languages);
         }
     }

--- a/Command/InitializeBundleCommand.php
+++ b/Command/InitializeBundleCommand.php
@@ -2,13 +2,11 @@
 
 namespace Lsw\GettextTranslationBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use Symfony\Component\Finder\Finder;
+use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
 /**
@@ -61,6 +59,8 @@ EOT
      * @param OutputInterface $output Output interface
      *
      * @see Command
+     *
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -78,6 +78,8 @@ EOT
         foreach ($results as $filename => $status) {
             $output->writeln("$status: $filename");
         }
+
+        return 0;
     }
 
     /**
@@ -87,39 +89,41 @@ EOT
      * @param OutputInterface $output Output interface
      *
      * @see Command
-     * @return mixed
+     * @return void
      */
     protected function interact(InputInterface $input, OutputInterface $output)
     {
-        if (!$input->getArgument('bundle')) {
-            $bundle = $this->getHelper('dialog')->askAndValidate(
-                $output,
-                'Please give the bundle:',
-                function($bundle)
-                {
-                    if (empty($bundle)) {
-                        throw new \Exception('Bundle can not be empty');
-                    }
+        $questionHelper = $this->getHelper('question');
 
-                    return $bundle;
+        if (!$input->getArgument('bundle')) {
+            $bundleQuestion = new Question('Please give the bundle: ');
+            $bundleQuestion->setValidator(function ($bundle) {
+                if (empty($bundle)) {
+                    throw new \RuntimeException(
+                        'Bundle can not be empty'
+                    );
                 }
-            );
+
+                return $bundle;
+            });
+
+            $bundle = $questionHelper->ask($input, $output, $bundleQuestion);
             $input->setArgument('bundle', $bundle);
         }
 
         if (!$input->getArgument('languages')) {
-            $languages = $this->getHelper('dialog')->askAndValidate(
-                $output,
-                'Please enter the list of languages (comma seperated):',
-                function($languages)
-                {
-                  if (empty($languages)) {
-                    throw new \Exception('Language list can not be empty');
-                  }
-
-                  return $languages;
+            $languageQuestion = new Question('Please enter the list of languages (comma seperated): ');
+            $languageQuestion->setValidator(function ($languages) {
+                if (empty($languages)) {
+                    throw new \RuntimeException(
+                        'Language list can not be empty'
+                    );
                 }
-            );
+
+                return $languages;
+            });
+
+            $languages = $questionHelper->ask($input, $output, $languageQuestion);
             $input->setArgument('languages', $languages);
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": ">=2.1",
-        "twig/twig": "~1.12"
+        "twig/twig": ">=1.12"
     },
     "require-dev": {
     },

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.1",
-        "twig/twig": ">=1.12"
+        "symfony/framework-bundle": ">=2.5",
+        "twig/twig": ">=1.18.1"
     },
     "require-dev": {
     },


### PR DESCRIPTION
In the current composer.json dependencies configuration — twig downgraded from v2.* branch to v1.*.

> `Changelogs summary:`
> `- twig/twig downgraded from v2.1.0 to v1.31.0`

I fixed it.

Also I corrected the BC issues with symfony 3+ Command & Process components.

Minimum versions of the Symfony and Twig increased to 2.5 and 1.18.1.