### PR TITLE
Minimal fix: Replaced setStdin with setInput

### DIFF
--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -163,7 +163,7 @@ abstract class AbstractCommand extends ContainerAwareCommand
         ));
 
         $process = new Process('xgettext '.$options);
-        $process->setStdin(implode("\n", $files));
+        $process->setInput(implode("\n", $files));
         $process->run();
         $output = $process->getOutput();
         if (!$process->isSuccessful()) {
@@ -255,7 +255,7 @@ abstract class AbstractCommand extends ContainerAwareCommand
         ));
 
         $process = new Process('msgcat '.$options);
-        $process->setStdin(implode("\n", $files));
+        $process->setInput(implode("\n", $files));
         $process->run();
         $output = $process->getOutput();
 

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,12 @@
             "email": "m.vanderschee@leaseweb.com"
         }
     ],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.1",
-        "twig/twig": "~1.12"
+        "symfony/framework-bundle": "^2.1|^3.0",
+        "twig/twig": "~1.12",
+        "symfony/process": "^2.5|^3.0"
     },
     "require-dev": {
     },


### PR DESCRIPTION
The [`Process::setStdin`](http://api.symfony.com/2.8/Symfony/Component/Process/Process.html#method_setStdin) function is removed in symfon/process:3.0 in favor of `setInput`.

This minimal PR fixes only that error.